### PR TITLE
Update localhost.yml so that warning does not appear

### DIFF
--- a/localhost.yml
+++ b/localhost.yml
@@ -1,7 +1,6 @@
 - hosts: localhost
   connection: local
   gather_facts: no
-  sudo: no
   vars_files:
     - vars.yml
   vars:
@@ -120,7 +119,7 @@
     # brew tap
     - name: install taps of homebrew
       homebrew_tap: tap="{{ item }}" state=present
-      with_items: homebrew_taps
+      with_items: "{{ homebrew_taps }}"
       tags:
         - brew
 
@@ -133,19 +132,19 @@
     # brew instal
     - name: install homebrew packages
       homebrew: name="{{ item.name }}" state="{{ item.state|default('latest') }}" install_options="{{ item.install_options|default() }}"
-      with_items: homebrew_packages
+      with_items: "{{ homebrew_packages }}"
       tags:
         - brew
 
     # brew cask install
     - name: install homebrew cask packages
       homebrew_cask: name="{{ item }}" state=present
-      with_items: homebrew_cask_packages
+      with_items: "{{ homebrew_cask_packages }}"
 
     # npm -g install
     - name: install npm packages
       npm: name="{{ item.name }}" state="{{ item.state|default('latest') }}" version="{{ item.version|default() }}" global=yes
-      with_items: npm_packages
+      with_items: "{{ npm_packages }}"
       tags:
         - npm
 


### PR DESCRIPTION
I've got the following warnings with Ansible 2.0:

> [DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and 
> make sure become_method is 'sudo' (default). This feature will be removed in a 
> future release. Deprecation warnings can be disabled by setting 
> deprecation_warnings=False in ansible.cfg.
> 
> [DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks
>  so that the environment value uses the full variable syntax 
> ('{{homebrew_taps}}'). This feature will be removed in a future release. 
> Deprecation warnings can be disabled by setting deprecation_warnings=False in 
> ansible.cfg.
